### PR TITLE
Just fixed a simple out of range error on the GestureTable app

### DIFF
--- a/GestureTable/app/gesture_recognizer.rb
+++ b/GestureTable/app/gesture_recognizer.rb
@@ -46,7 +46,7 @@ class GestureRecognizer
 
   def updateAddingIndexPathForCurrentLocation
     indexPath = indexPathFromRecognizer(@longPressRecognizer)
-    if indexPath != @addingIndexPath
+    if indexPath && indexPath != @addingIndexPath
       @tableView.beginUpdates
       @tableView.deleteRowsAtIndexPaths([@addingIndexPath], withRowAnimation: UITableViewRowAnimationNone)
       @tableView.insertRowsAtIndexPaths([indexPath], withRowAnimation: UITableViewRowAnimationNone)


### PR DESCRIPTION
If you drag the long hold item above or below the other cells it causes an error
