### PR TITLE
Refactoring to avoid tight coupling

### DIFF
--- a/Beers/app/app_delegate.rb
+++ b/Beers/app/app_delegate.rb
@@ -2,7 +2,7 @@ class AppDelegate
   def application(application, didFinishLaunchingWithOptions:launchOptions)
     @window = UIWindow.alloc.initWithFrame(UIScreen.mainScreen.bounds)
     tabbar = UITabBarController.alloc.init
-    beer_list_controller = BeerListController.alloc.init(beer_details_controller)
+    beer_list_controller = BeerListController.alloc.initWithDetailsController(beer_details_controller)
     tabbar.viewControllers = [BeerMapController.alloc.init, beer_list_controller]
     tabbar.selectedIndex = 0
     @window.rootViewController = UINavigationController.alloc.initWithRootViewController(tabbar)

--- a/Beers/app/app_delegate.rb
+++ b/Beers/app/app_delegate.rb
@@ -2,7 +2,8 @@ class AppDelegate
   def application(application, didFinishLaunchingWithOptions:launchOptions)
     @window = UIWindow.alloc.initWithFrame(UIScreen.mainScreen.bounds)
     tabbar = UITabBarController.alloc.init
-    tabbar.viewControllers = [BeerMapController.alloc.init, BeerListController.alloc.init]
+    beer_list_controller = BeerListController.alloc.init(beer_details_controller)
+    tabbar.viewControllers = [BeerMapController.alloc.init, beer_list_controller]
     tabbar.selectedIndex = 0
     @window.rootViewController = UINavigationController.alloc.initWithRootViewController(tabbar)
     @window.rootViewController.wantsFullScreenLayout = true

--- a/Beers/app/beer_list_controller.rb
+++ b/Beers/app/beer_list_controller.rb
@@ -1,6 +1,7 @@
 class BeerListController < UITableViewController
-  def init
-    if super
+  def init(beer_details_controller)
+    @beer_details_controller = beer_details_controller
+    if super()
       self.tabBarItem = UITabBarItem.alloc.initWithTitle('List', image:UIImage.imageNamed('list.png'), tag:1)
     end
     self
@@ -33,8 +34,7 @@ class BeerListController < UITableViewController
 
   def tableView(tableView, accessoryButtonTappedForRowWithIndexPath:indexPath)
     beer = Beer::All[indexPath.row]
-    controller = UIApplication.sharedApplication.delegate.beer_details_controller
-    navigationController.pushViewController(controller, animated:true)
-    controller.showDetailsForBeer(beer)
+    navigationController.pushViewController(@beer_details_controller, animated:true)
+    @beer_details_controller.showDetailsForBeer(beer)
   end
 end

--- a/Beers/app/beer_list_controller.rb
+++ b/Beers/app/beer_list_controller.rb
@@ -1,7 +1,7 @@
 class BeerListController < UITableViewController
-  def init(beer_details_controller)
+  def initWithDetailsController(beer_details_controller)
     @beer_details_controller = beer_details_controller
-    if super()
+    if init
       self.tabBarItem = UITabBarItem.alloc.initWithTitle('List', image:UIImage.imageNamed('list.png'), tag:1)
     end
     self

--- a/Beers/app/beer_map_controller.rb
+++ b/Beers/app/beer_map_controller.rb
@@ -1,6 +1,7 @@
 class BeerMapController < UIViewController
-  def init
-    if super
+  def initWithDetailsController(beer_details_controller)
+    @beer_details_controller = beer_details_controller
+    if init
       self.tabBarItem = UITabBarItem.alloc.initWithTitle('Map', image:UIImage.imageNamed('map.png'), tag:1)
     end
     self
@@ -43,8 +44,7 @@ class BeerMapController < UIViewController
   def showDetails(sender)
     if view.selectedAnnotations.size == 1
       beer = view.selectedAnnotations[0]
-      controller = UIApplication.sharedApplication.delegate.beer_details_controller
-      navigationController.pushViewController(controller, animated:true)
+      navigationController.pushViewController(@beer_details_controller, animated:true)
       controller.showDetailsForBeer(beer)
     end
   end


### PR DESCRIPTION
This code demonstrates how BeerDetailsController can be injected as a dependency into BeerListController. This avoids the awkward chained call of BeerDetailsController via UIApplication (which violates the Law Of Demeter).
