### PR TITLE
Very minor naming issue in paint_view/initWithFrame

### DIFF
--- a/Paint/app/paint_view.rb
+++ b/Paint/app/paint_view.rb
@@ -1,5 +1,5 @@
 class PaintView < UIView
-  def initWithFrame(ect)
+  def initWithFrame(rect)
     if super
       path = NSBundle.mainBundle.pathForResource('erase', ofType:'caf')
       url = NSURL.fileURLWithPath(path)


### PR DESCRIPTION
`initWithFrame(ect)` was probably supposed to be `initWithFrame(rect)`
