### PR TITLE
Fixed GestureTable build error

### DIFF
--- a/ios/GestureTable/app/transformable_cells.rb
+++ b/ios/GestureTable/app/transformable_cells.rb
@@ -1,5 +1,5 @@
 class TransformableTableViewCell < UITableViewCell
-  attr_accessor :finishedHeight, :tintColor
+  attr_accessor :finishedHeight
 
   def self.transformableTableViewCellWithStyle(style, reuseIdentifier: reuseIdentifier)
     case style
@@ -10,6 +10,14 @@ class TransformableTableViewCell < UITableViewCell
     else
       raise ArgumentError, "Style must be :pullDown or :unfolding"
     end
+  end
+
+  def tinyColor=(tinyColor)
+    @tinyColor = tinyColor
+  end
+
+  def tinyColor
+    @tinyColor
   end
 end
 


### PR DESCRIPTION
GestureTable build error in my system (OSX 10.8.5, RubyMotion 2.11, Xcode 5.0)

```
$ rake
Build ./build/iPhoneSimulator-7.0-Development
Compile ./app/gesture_recognizer.rb
Compile ./app/UITableView_extensions.rb
Compile ./app/transformable_cells.rb
Compile ./app/UIColor_extensions.rb
Compile ./app/app_delegate.rb
Compile ./app/view_controller.rb
Create ./build/iPhoneSimulator-7.0-Development/Gesture Table.app
Link ./build/iPhoneSimulator-7.0-Development/Gesture Table.app/Gesture Table
Create ./build/iPhoneSimulator-7.0-Development/Gesture Table.app/PkgInfo
Create ./build/iPhoneSimulator-7.0-Development/Gesture Table.app/Info.plist
Copy ./resources/Default-568h@2x.png
Create ./build/iPhoneSimulator-7.0-Development/Gesture Table.dSYM
Simulate ./build/iPhoneSimulator-7.0-Development/Gesture Table.app
<PullDownTableViewCell 0xa6818e0> method `tintColor' created by attr_reader/writer or define_method cannot be called from Objective-C. Please manually define the method instead (using the `def' keyword).((null))
```

I fixed it.
