### PR TITLE
Update Camera sample Rakefile to require 'motion/project/template/ios'

### DIFF
--- a/ios/Camera/Rakefile
+++ b/ios/Camera/Rakefile
@@ -1,6 +1,6 @@
 # coding: utf-8
 $:.unshift("/Library/RubyMotion/lib")
-require 'motion/project'
+require 'motion/project/template/ios'
 
 Motion::Project::App.setup do |app|
   # Use `rake config' to see complete project settings.


### PR DESCRIPTION
In recent releases of RubyMotion, `Rakefile`s are to require 'motion/project/template/ios' instead of 'motion/project' 
