### PR TITLE
Fix red component of random color

### DIFF
--- a/ios/Paint/app/paint_view.rb
+++ b/ios/Paint/app/paint_view.rb
@@ -28,7 +28,7 @@ class PaintView < UIView
     bp.lineWidth = 3.0
     random_color = begin
       red, green, blue = rand(100)/100.0, rand(100)/100.0, rand(100)/100.0
-      UIColor.alloc.initWithRed(red/100.0, green:green, blue:blue, alpha:1.0)
+      UIColor.alloc.initWithRed(red, green:green, blue:blue, alpha:1.0)
     end
     @paths << [bp, random_color]
   end


### PR DESCRIPTION
The red component was being divided by 100 twice, yielding a color with almost no red component. Removes the second division.